### PR TITLE
Unhandled TypeError on non-alphanumeric keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,8 @@ List.prototype.__proto__ = Emitter.prototype;
  */
 
 List.prototype.onkeypress = function(ch, key){
+  if (!key) return;
+
   this.emit('keypress', key, this.selected);
   switch (key.name) {
     case 'k':


### PR DESCRIPTION
Non-alphanumeric keys, e.g. `,/?.`, cause a TypeError on keypress.

```
/home/eyko/github/node-term-list/index.js:57
  switch (key.name) {
             ^
TypeError: Cannot read property 'name' of undefined
    at List.onkeypress (/home/eyko/github/node-term-list/index.js:57:14)
    at ReadStream.EventEmitter.emit (events.js:98:17)
    at emitKey (/home/eyko/github/node-term-list/node_modules/keypress/index.js:406:12)
    at ReadStream.onData (/home/eyko/github/node-term-list/node_modules/keypress/index.js:48:14)
    at ReadStream.EventEmitter.emit (events.js:95:17)
    at ReadStream.<anonymous> (_stream_readable.js:746:14)
    at ReadStream.EventEmitter.emit (events.js:92:17)
    at emitReadable_ (_stream_readable.js:408:10)
    at emitReadable (_stream_readable.js:404:5)
    at readableAddChunk (_stream_readable.js:165:9)
```

@ledbettj reported it over here: turingou/btc#1 so stopping the event from being triggered would prevent the same error when requiring the lib.
