### PR TITLE
https => http for image url

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,11 +1,10 @@
-
 # term-list
 
   Renders an interactive list to the terminal that users
   can navigate using the arrow keys. Developers can bind
   to "keypress" events to support removal or opening of items etc.
 
-  ![interactive terminal list](https://dsz91cxz97a03.cloudfront.net/YNqOchbrMD-150x150.png)
+  ![interactive terminal list](http://dsz91cxz97a03.cloudfront.net/YNqOchbrMD-150x150.png)
 
 ## Installation
 


### PR DESCRIPTION
Because in Safari and Chrome (I only tested this on those two browsers), the image will not show up until you put the "https" image url into a separate browser window and accept the certificate. Upon doing this, then subsequently refreshing the readme page, the image shows. Unfortunately, most people won't know to do this and will simply be frustrated that the image does show up.
